### PR TITLE
fix navbar menu card size on hover

### DIFF
--- a/style.css
+++ b/style.css
@@ -1269,7 +1269,7 @@ nav ul li a:hover {
     height: 3px;
     width: 100%;
     background: black;
-    bottom: -15px;
+    bottom: -14px;
     left: 0.5rem;
     transform: scale(0, 1);
   }


### PR DESCRIPTION
On hover, selected menu just getting out of navbar

before:
<img width="300" alt="image" src="https://github.com/kd1729/portfolio/assets/58323485/cb3c05f3-0afb-4692-b162-2224b69ad82f">

after:
<img width="300" alt="image" src="https://github.com/kd1729/portfolio/assets/58323485/ad67b7e0-6e0b-4c8f-b588-db660ef40fed">

please add hacktoberfest label
